### PR TITLE
Add custom entrypoint to use 2 worker

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,7 @@
 runtime: python39
 
+entrypoint: gunicorn -w 2 main:app
+
 handlers:
 - url: /static
   static_dir: static

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,6 +8,7 @@ configGenerate() {
 }
 
 remote() {
+	if [ -n "$1" ]; then PROJECT_ID=$1; fi
 	if gcloud projects describe "$PROJECT_ID" 2>&1 > /dev/null; then
 		echo "Project ID $PROJECT_ID"
 	else
@@ -54,7 +55,7 @@ case "$1" in
 		fi
 		;;
     remote)
-		remote
+		remote $2
 		;;
 	config)
 		echo "Generate config file in app-deploy.yaml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gunicorn==20.1.0
 Flask==2.3.2
 requests==2.24.0
 google-cloud-compute==1.11.0


### PR DESCRIPTION
Add custom entrypoint reduce gunicorn worker to 2
It also fix the memory issue at start up
Ref: https://cloud.google.com/appengine/docs/standard/python3/runtime#entrypoint_best_practices